### PR TITLE
Fix SDL2_mixer linking errors on MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdl2)
 find_package(SDL2 REQUIRED)
 find_package(SDL2_mixer REQUIRED)
 
+if(MINGW)
+    set(SDL2_LIBRARIES mingw32 SDL2main SDL2 SDL2_mixer)
+endif()
+
 add_definitions(-Wall -D_REENTRANT -D_THREAD_SAFE)
 
 add_executable(sdl2-doom src/i_main.c src/dummy.c src/am_map.c src/doomdef.c src/doomstat.c src/dstrings.c src/d_event.c


### PR DESCRIPTION
Fix SDL2_mixer linking errors on MinGW.

Tested with MinGW64 g++.exe (Rev2, Built by MSYS2 project) 14.2.0, SDL Mixer 2.8.0, SDL 2.30.11 on Windows 11.

