### PR TITLE
Fix joystick build error

### DIFF
--- a/src/i_joystick.c
+++ b/src/i_joystick.c
@@ -157,7 +157,7 @@ void I_InitJoystick(void)
 
     // Initialized okay!
 
-    printf("I_InitJoystick: %s\n", SDL_JoystickName(joystick_index));
+    printf("I_InitJoystick: %s\n", SDL_JoystickName(joystick));
 
     I_AtExit(I_ShutdownJoystick, true);
 }


### PR DESCRIPTION
Fixing this build error:

```
error: passing argument 1 of 'SDL_JoystickName' makes pointer from integer without a cast [-Wint-conversion]
  160 |     printf("I_InitJoystick: %s\n", SDL_JoystickName(joystick_index));
```

I got this build error when building on Windows 11 using  MinGW64 g++.exe (Rev2, Built by MSYS2 project) 14.2.0, SDL Mixer 2.8.0, SDL 2.30.11.